### PR TITLE
New FormatScrapers in BaseScraper

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: 5.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: 5.0.x
     - name: Set VERSION variable from tag
       run: echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
     - name: Install dependencies

--- a/RecipeScraper.IntegrationTests/RecipeScraper.IntegrationTests.csproj
+++ b/RecipeScraper.IntegrationTests/RecipeScraper.IntegrationTests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/RecipeScraper/Helpers/AngleSharpHelpers.cs
+++ b/RecipeScraper/Helpers/AngleSharpHelpers.cs
@@ -1,0 +1,70 @@
+﻿using AngleSharp.Dom;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RecipeScraper.Helpers
+{
+    internal static class AngleSharpHelpers
+    {
+        public static IElement GetSingleItemPropElementFromPageContent(string itemPropName, IDocument pageContent)
+        {
+            return pageContent.All.FirstOrDefault(x => x.HasAttribute("itemprop") && x.GetAttribute("itemprop").StartsWith(itemPropName));
+        }
+
+        public static List<IElement> GetMultipleItemPropElementsFromPageContent(string itemPropName, IDocument pageContent)
+        {
+            return pageContent.All.Where(x => x.HasAttribute("itemprop") && x.GetAttribute("itemprop").StartsWith(itemPropName)).ToList();
+        }
+
+        public static IElement FindListParentNodeRecursive(IElement node)
+        {
+            if (node.Children.Length > 1)
+            {
+                return node;
+            }
+
+            return FindListParentNodeRecursive(node.ParentElement);
+        }
+
+        public static IElement FindCommonParentNodeRecursive(IElement node1, IElement node2)
+        {
+            var parent1 = node1.ParentElement;
+            var parent2 = node2.ParentElement;
+            
+            if (parent1 == null || parent2 == null)
+                return null;
+            
+            if (parent1 == parent2)
+                return node1.ParentElement;
+
+            return FindCommonParentNodeRecursive(parent1, parent2);
+        }
+
+        public static List<string> GetTextContentOfNodeRecursive(IElement node, int recurseCount)
+        {
+            var textContents = new List<string>();
+
+            if (node == null || recurseCount > 10)
+                return textContents;
+
+            recurseCount++;
+
+            if (node.Children.Length == 0 && !string.IsNullOrEmpty(node.TextContent))
+            {
+                textContents.Add(node.TextContent);
+            }
+            else if (node.Children.Length > 0)
+            {
+                foreach (var childNode in node.Children)
+                {
+                    textContents.AddRange(GetTextContentOfNodeRecursive(childNode, recurseCount));
+                }
+            }
+
+            return textContents;
+        }
+    }
+}

--- a/RecipeScraper/RecipeScraper.csproj
+++ b/RecipeScraper/RecipeScraper.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <PackageProjectUrl>https://github.com/simfoley/RecipeScraper</PackageProjectUrl>
     <Authors>Simon Foley</Authors>
     <Description>

--- a/RecipeScraper/Scrapers/FromatScrapers/HtlmTreeParsingScraper.cs
+++ b/RecipeScraper/Scrapers/FromatScrapers/HtlmTreeParsingScraper.cs
@@ -1,0 +1,213 @@
+﻿using AngleSharp.Dom;
+using RecipeScraper.Helpers;
+using RecipeScraper.Scrapers.FromatScrapers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace RecipeScraper.Scrapers.FormatScrapers
+{
+    internal class HtlmTreeParsingScraper : IFormatScraper
+    {
+        private struct NodeWithScore
+        {
+            public int Score { get; set; }
+            public IElement Node { get; set; }
+        }
+
+        private List<string> CommonIngredients = new List<string> { "butter", "beurre", "olive oil", "huile d'olive", "salt", "sel", "pepper", "poivre" };
+        private List<string> CommonUnits = new List<string> { "cup", "tasse", "ml", "kg", "gram", "g ", "lb" };
+        private List<string> InstructionsCommonWords = new List<string> { "preheat", "préchauffer", "bring to a boil", "porter à ébullition", "bake", "cuire", "baking", "cuisson" };
+
+        private IDocument _pageContent;
+        private IElement _ingredientsParent = null;
+        private IElement _instructionsParent = null;
+        private List<NodeWithScore> _ingredientNodes = new List<NodeWithScore>();
+        private List<NodeWithScore> _instructionNodes = new List<NodeWithScore>();
+
+        public bool IsActive => _ingredientNodes.Count > 0 || _instructionNodes.Count > 0;
+
+        //Property that determines if the webpage is just a flat list of tags
+        private bool IsFlatWebPage => _ingredientsParent!= null && _ingredientsParent == _instructionsParent;
+
+        public HtlmTreeParsingScraper(IDocument pageContent) 
+        {
+            _pageContent = pageContent;
+            FindIngredientAndInstructionNodes();
+        }
+
+        public string GetName()
+        {
+            string name = null;
+
+            name = _pageContent.Title;
+
+            if (string.IsNullOrEmpty(name))
+            {
+                name = _pageContent.All.FirstOrDefault(x => x.HasAttribute("property") && x.GetAttribute("property").StartsWith("og:title"))?.GetAttribute("content");
+            }
+
+            return name;
+        }
+
+        public string GetYield()
+        {
+            return null;
+        }
+
+        public string GetImage()
+        {
+            return null;
+        }
+
+        public string GetPrepTime()
+        {
+            return string.Empty;
+        }
+
+        public string GetCookTime()
+        {
+            return string.Empty;
+        }
+
+        public List<string> GetRecipeIngredients()
+        {
+            var recipeIngredients = new List<string>();
+            if (_ingredientNodes.Count > 0)
+            {
+                if (IsFlatWebPage)
+                {
+                    recipeIngredients.AddRange(_ingredientNodes.Select(x => x.Node.TextContent));
+                }
+                else
+                {
+                    recipeIngredients = AngleSharpHelpers.GetTextContentOfNodeRecursive(_ingredientsParent, 0);
+                }
+            }
+            return recipeIngredients;
+            
+        }
+
+        public List<string> GetRecipeInstructions()
+        {
+            var recipeInstructions = new List<string>();
+            if (_instructionNodes.Count > 0)
+            {
+                if (IsFlatWebPage)
+                {
+                    recipeInstructions.AddRange(_instructionNodes.Select(x => x.Node.TextContent));
+                }
+                else
+                {
+                    recipeInstructions = AngleSharpHelpers.GetTextContentOfNodeRecursive(_instructionsParent, 0);
+                }
+            }
+            return recipeInstructions;
+        }
+
+        private void FindIngredientAndInstructionNodes()
+        {
+            foreach (var node in _pageContent.All.Where(x => !string.IsNullOrEmpty(x.TextContent)))
+            {
+                string textContent = node.TextContent;
+                var ingredientScore = CalculateTextIngredientScore(textContent);
+                var instructionScore = CalculateTextInstructionScore(textContent);
+
+                if (ingredientScore >= 70)
+                {
+                    _ingredientNodes.Add(new NodeWithScore { Score = ingredientScore, Node = node});
+                }
+
+                if (instructionScore >= 70)
+                {
+                    _instructionNodes.Add(new NodeWithScore { Score = instructionScore, Node = node });
+                }
+            }
+
+            _ingredientNodes = _ingredientNodes.GroupBy(p => p.Node.TextContent).Select(g => g.First()).OrderByDescending(x => x.Score).ToList();
+            _instructionNodes = _instructionNodes.GroupBy(p => p.Node.TextContent).Select(g => g.First()).OrderByDescending(x => x.Score).ToList();
+
+            //If we have more than 1 node, try finding common parent for better results, otherwise, find first parent node that contains multiple children
+            if (_ingredientNodes.Count > 1)
+            {
+                _ingredientsParent = AngleSharpHelpers.FindCommonParentNodeRecursive(_ingredientNodes[0].Node, _ingredientNodes[1].Node);
+            }
+            if (_ingredientsParent == null && _ingredientNodes.Count >= 1)
+            {
+                _ingredientsParent = AngleSharpHelpers.FindListParentNodeRecursive(_ingredientNodes[0].Node);
+            }
+
+            if (_instructionNodes.Count > 1)
+            {
+                _instructionsParent = AngleSharpHelpers.FindCommonParentNodeRecursive(_instructionNodes[0].Node, _instructionNodes[1].Node);
+            }
+            if (_instructionsParent == null && _instructionNodes.Count >= 1)
+            {
+                _instructionsParent = AngleSharpHelpers.FindListParentNodeRecursive(_instructionNodes[0].Node);
+            }
+        }
+
+        //Gives given text probability it is an ingredient on 100
+        private int CalculateTextIngredientScore(string text)
+        {
+            int nodeScore = 0;
+
+            if (text.Length < 50 && text.Length >= 3)
+            {
+                nodeScore += 30;
+            }
+            if (CommonIngredients.Any(ingredient => text.Contains(ingredient, StringComparison.CurrentCultureIgnoreCase)))
+            {
+                nodeScore += 30;
+            }
+            if (CommonUnits.Any(unit => text.Contains(unit, StringComparison.CurrentCultureIgnoreCase)))
+            {
+                nodeScore += 10;
+            }
+            if (Char.IsDigit(text[0]))
+            {
+                nodeScore += 20;
+            }
+            if (!text.Contains(". "))
+            {
+                nodeScore += 10;
+            }
+
+            return nodeScore;
+        }
+
+        //Gives given text probability it is an ingredient on 100
+        private int CalculateTextInstructionScore(string text)
+        {
+            int nodeScore = 0;
+
+            if (text.Length > 50 && text.Length < 500)
+            {
+                nodeScore += 30;
+            }
+            if (InstructionsCommonWords.Any(instruction => text.Contains(instruction, StringComparison.CurrentCultureIgnoreCase)))
+            {
+                nodeScore += 30;
+            }
+            if (Char.IsUpper(text[0]))
+            {
+                nodeScore += 10;
+            }
+            if (text.Contains(". "))
+            {
+                nodeScore += 20;
+            }
+            if (Char.IsPunctuation(text[text.Length - 1]))
+            {
+                nodeScore += 10;
+            }
+            if (text.Contains("{") || text.Contains("}"))
+            {
+                nodeScore = 0;
+            }
+
+            return nodeScore;
+        }
+    }
+}

--- a/RecipeScraper/Scrapers/FromatScrapers/IFormatScraper.cs
+++ b/RecipeScraper/Scrapers/FromatScrapers/IFormatScraper.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RecipeScraper.Scrapers.FromatScrapers
+{
+    internal interface IFormatScraper
+    {
+        bool IsActive { get; }
+
+        string GetName();
+        string GetYield();
+        string GetImage();
+        string GetPrepTime();
+        string GetCookTime();
+        List<string> GetRecipeIngredients();
+        List<string> GetRecipeInstructions();
+    }
+}

--- a/RecipeScraper/Scrapers/FromatScrapers/JsonLdScraper.cs
+++ b/RecipeScraper/Scrapers/FromatScrapers/JsonLdScraper.cs
@@ -1,0 +1,190 @@
+﻿using AngleSharp.Dom;
+using RecipeScraper.Scrapers.FromatScrapers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+
+namespace RecipeScraper.Scrapers.FormatScrapers
+{
+    internal class JsonLdScraper : IFormatScraper
+    {
+        private JsonElement _jsonRecipe;
+        public bool IsActive => _jsonRecipe.ValueKind != JsonValueKind.Undefined;
+        
+        public JsonLdScraper(IDocument pageContent)
+        {
+            foreach (var htmlElement in pageContent.Scripts.Where(x => x.Type == "application/ld+json" && (x.InnerHtml.Contains("\"@type\":\"Recipe\"") || x.InnerHtml.Contains("\"@type\": \"Recipe\""))))
+            {
+                var jsonElement = JsonDocument.Parse(htmlElement.InnerHtml).RootElement;
+
+                
+                if (jsonElement.ValueKind == JsonValueKind.Object && jsonElement.TryGetProperty("@type", out JsonElement recipeType) && recipeType.GetString() == "Recipe")
+                {
+                    _jsonRecipe = jsonElement;
+                    return;
+                }
+                else if (jsonElement.ValueKind == JsonValueKind.Object && jsonElement.TryGetProperty("@graph", out JsonElement graphType) && graphType.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var graphElement in jsonElement.GetProperty("@graph").EnumerateArray())
+                    {
+                        if (graphElement.ValueKind == JsonValueKind.Object && graphElement.TryGetProperty("@type", out JsonElement graphElementType) && graphElementType.GetString() == "Recipe")
+                        {
+                            _jsonRecipe = graphElement;
+                            return;
+                        }
+                    }    
+                }
+                else if (jsonElement.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var innerJsonElement in jsonElement.EnumerateArray())
+                    {
+                        if (innerJsonElement.ValueKind == JsonValueKind.Object && innerJsonElement.TryGetProperty("@type", out JsonElement innerType) && innerType.GetString() == "Recipe")
+                        {
+                            _jsonRecipe = innerJsonElement;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
+        public string GetName()
+        {
+            string name = null;
+            
+            if (_jsonRecipe.GetProperty("name").ValueKind == JsonValueKind.String)
+            {
+                name = _jsonRecipe.GetProperty("name").GetString();
+            }
+
+            return name;
+        }
+
+        public string GetImage()
+        {
+            string imageSource = null;
+
+            var imageProperty = _jsonRecipe.GetProperty("image");
+            if (imageProperty.ValueKind == JsonValueKind.Array)
+            {
+                imageSource = imageProperty[0].GetString();
+            }
+            if (imageProperty.ValueKind == JsonValueKind.Object)
+            {
+                if (imageProperty.GetProperty("url").ValueKind == JsonValueKind.String)
+                {
+                    imageSource = imageProperty.GetProperty("url").GetString();
+                }
+            }
+            else if (imageProperty.ValueKind == JsonValueKind.String)
+            {
+                imageSource = imageProperty.GetString();
+            }
+
+            return imageSource;
+        }
+
+        public string GetYield()
+        {
+            string yield = null;
+            
+            if (_jsonRecipe.GetProperty("recipeYield").ValueKind == JsonValueKind.String)
+            {
+                yield = _jsonRecipe.GetProperty("recipeYield").GetString();
+            }
+
+            return yield;
+        }
+
+        public string GetPrepTime()
+        {
+            string prepTime = string.Empty;
+
+            //Json LD
+            if (_jsonRecipe.GetProperty("prepTime").ValueKind == JsonValueKind.String)
+            {
+                prepTime = _jsonRecipe.GetProperty("prepTime").GetString();
+            }
+
+            return prepTime;
+        }
+
+        public string GetCookTime()
+        {
+            string cookTime = string.Empty;
+            
+            if (_jsonRecipe.GetProperty("cookTime").ValueKind == JsonValueKind.String)
+            {
+                cookTime = _jsonRecipe.GetProperty("cookTime").GetString();
+            }
+
+            return cookTime;
+        }
+
+        public List<string> GetRecipeIngredients()
+        {
+            var recipeIngredients = new List<string>();
+            
+            foreach (var ingredient in _jsonRecipe.GetProperty("recipeIngredient").EnumerateArray())
+            {
+                if (ingredient.ValueKind == JsonValueKind.String)
+                {
+                    recipeIngredients.Add(ingredient.ToString());
+                }
+            }
+
+            return recipeIngredients;
+        }
+
+        public List<string> GetRecipeInstructions()
+        {
+            var recipeInstructions = new List<string>();
+
+            //Json LD
+            if (_jsonRecipe.ValueKind != JsonValueKind.Undefined)
+            {
+                var instructionSection = _jsonRecipe.GetProperty("recipeInstructions");
+                recipeInstructions.AddRange(GetRecipeInstrctionsRecursive(instructionSection));
+            }
+
+            return recipeInstructions;
+        }
+
+        //Because recipeInstruction can be in different formats in json-ld, just recurse through the json and keep the "text" properties values. 
+        private List<string> GetRecipeInstrctionsRecursive(JsonElement element, int recurseCount = 0)
+        {
+            var result = new List<string>();
+
+            if (recurseCount > 10)
+                return result;
+
+            recurseCount++;
+
+            if (element.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in element.EnumerateArray())
+                {
+                    result.AddRange(GetRecipeInstrctionsRecursive(item, recurseCount));
+                }
+            }
+            else if (element.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var item in element.EnumerateObject())
+                {
+                    if (item.Value.ValueKind == JsonValueKind.Object || item.Value.ValueKind == JsonValueKind.Array)
+                    {
+                        result.AddRange(GetRecipeInstrctionsRecursive(item.Value, recurseCount));
+                    }
+                    else if (item.Name == "text")
+                    {
+                        result.Add(item.Value.ToString());
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/RecipeScraper/Scrapers/FromatScrapers/MircrodataScraper.cs
+++ b/RecipeScraper/Scrapers/FromatScrapers/MircrodataScraper.cs
@@ -1,0 +1,155 @@
+﻿using AngleSharp.Dom;
+using RecipeScraper.Helpers;
+using RecipeScraper.Scrapers.FromatScrapers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace RecipeScraper.Scrapers.FormatScrapers
+{
+    internal class MircrodataScraper : IFormatScraper
+    {
+        public bool IsActive => _pageContent.All.FirstOrDefault(x => x.HasAttribute("itemprop")) != null;
+        private IDocument _pageContent;
+
+        public MircrodataScraper(IDocument pageContent)
+        {
+            _pageContent = pageContent;
+        }
+
+        public string GetName()
+        {
+            string name = null;
+
+            var nameElements = AngleSharpHelpers.GetMultipleItemPropElementsFromPageContent("name", _pageContent);
+            if (nameElements.Count > 1)
+            {
+                name = nameElements.FirstOrDefault(x => x.ParentElement.HasAttribute("itemtype") && x.ParentElement.GetAttribute("itemtype").StartsWith("http://schema.org/Recipe")).TextContent.Trim();
+            }
+            else if (nameElements.Count == 1)
+            {
+                name = nameElements.First().TextContent.Trim();
+            }
+
+            return name;
+        }
+
+        public string GetYield()
+        {
+            string yield = null;
+
+            var yieldElement = AngleSharpHelpers.GetSingleItemPropElementFromPageContent("recipeYield", _pageContent);
+            if (yieldElement?.LocalName == "meta")
+            {
+                yield = yieldElement.GetAttribute("content");
+            }
+            else
+            {
+                yield = yieldElement?.TextContent.Trim();
+            }
+
+            return yield;
+        }
+
+        public string GetImage()
+        {
+            string imageSource = null;
+
+            IElement imageElement = null;
+            var imageElements = AngleSharpHelpers.GetMultipleItemPropElementsFromPageContent("image", _pageContent);
+            if (imageElements.Count == 1)
+            {
+                imageElement = imageElements.First();
+            }
+            else
+            {
+                imageElement = imageElements.FirstOrDefault(x => x.ParentElement.HasAttribute("itemtype") && x.ParentElement.GetAttribute("itemtype").StartsWith("http://schema.org/Recipe"));
+            }
+
+            if (imageElement?.LocalName == "img")
+            {
+                imageSource = imageElement.GetAttribute("src");
+            }
+            else if (imageElement != null)
+            {
+                imageSource = imageElement.TextContent.Trim();
+            }
+
+            return imageSource;
+        }
+
+        public string GetPrepTime()
+        {
+            string prepTime = string.Empty;
+
+            var prepTimeElement = AngleSharpHelpers.GetSingleItemPropElementFromPageContent("prepTime", _pageContent);
+            if (prepTimeElement?.LocalName == "time")
+            {
+                prepTime = prepTimeElement.GetAttribute("datetime");
+            }
+            else if (prepTimeElement?.LocalName == "meta")
+            {
+                prepTime = prepTimeElement.GetAttribute("content");
+            }
+            else
+            {
+                prepTime = prepTimeElement?.InnerHtml.Trim();
+            }
+
+            return prepTime;
+        }
+
+        public string GetCookTime()
+        {
+            string cookTime = string.Empty;
+
+            var cookTimeElement = AngleSharpHelpers.GetSingleItemPropElementFromPageContent("cookTime", _pageContent);
+            if (cookTimeElement?.LocalName == "time")
+            {
+                cookTime = cookTimeElement.GetAttribute("datetime");
+            }
+            else if (cookTimeElement?.LocalName == "meta")
+            {
+                cookTime = cookTimeElement.GetAttribute("content");
+            }
+            else
+            {
+                cookTime = cookTimeElement?.InnerHtml.Trim();
+            }
+
+            return cookTime;
+        }
+
+        public List<string> GetRecipeIngredients()
+        {
+            var recipeIngredients = new List<string>();
+           
+            var ingredientElements = AngleSharpHelpers.GetMultipleItemPropElementsFromPageContent("recipeIngredient", _pageContent);
+            if (!ingredientElements.Any())
+            {
+                ingredientElements = AngleSharpHelpers.GetMultipleItemPropElementsFromPageContent("ingredients", _pageContent);
+            }
+
+            foreach (var ingredient in ingredientElements)
+            {
+                recipeIngredients.Add(ingredient.TextContent.Trim());
+            }
+
+            return recipeIngredients;
+        }
+
+        public List<string> GetRecipeInstructions()
+        {
+            var recipeInstructions = new List<string>();
+
+            var instructionsElements = AngleSharpHelpers.GetMultipleItemPropElementsFromPageContent("recipeInstructions", _pageContent);
+            foreach (var instructionsElement in instructionsElements)
+            {
+                recipeInstructions.AddRange(AngleSharpHelpers.GetTextContentOfNodeRecursive(instructionsElement, 0));
+            }
+
+            return recipeInstructions;
+        }
+    }
+}

--- a/RecipeScraper/Scrapers/LeCoupDeGraceScraper.cs
+++ b/RecipeScraper/Scrapers/LeCoupDeGraceScraper.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace RecipeScraperLib.Scrapers
 {
-    public class LeCoupDeGraceScraper : BaseScraper
+    internal class LeCoupDeGraceScraper : BaseScraper
     {
         public LeCoupDeGraceScraper(string url) : base(url)
         { 


### PR DESCRIPTION
Use FormatScrapers in BaseScraper. BaseScraper now supports json ld, microdata and in last resort uses Html tree parsing to find potentiel ingredients or instructions