### PR TITLE
Add TotalTime field to ScrapedRecipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,20 @@ RecipeScraper.UnitTests/              # xUnit unit tests (no IO)
 3. `IRecipeScraper.ScrapeRecipe(url)` (implemented by `RecipeScraperBase`) fetches the page via AngleSharp and initialises three parsers in priority order: `JsonLdParser` → `MicrodataParser` → `HtmlTreeParser`
 4. Each `Get*` method iterates the parsers and returns the first non-null result
 
+## ScrapedRecipe model
+
+| Property                | Type        | Description                        |
+| ----------------------- | ----------- | ---------------------------------- |
+| `Name`                  | `string?`   | Recipe name                        |
+| `Image`                 | `string?`   | Image URL                          |
+| `Yield`                 | `string?`   | Serving size / yield               |
+| `PrepTime`              | `TimeSpan?` | Preparation time                   |
+| `CookTime`              | `TimeSpan?` | Cook time                          |
+| `TotalTime`             | `TimeSpan?` | Total time                         |
+| `RecipeIngredients`     | `string[]`  | List of ingredients                |
+| `RecipeInstructions`    | `string[]`  | List of instruction steps          |
+| `RecipeLanguageISOCode` | `string?`   | Language of the page (e.g. `"en"`) |
+
 ## Entry point for consumers
 
 ```csharp

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ public class MyClass(IRecipeScraperService scraper)
 | `Yield`                 | `string?`   | Serving size / yield               |
 | `PrepTime`              | `TimeSpan?` | Preparation time                   |
 | `CookTime`              | `TimeSpan?` | Cook time                          |
+| `TotalTime`             | `TimeSpan?` | Total time                         |
 | `RecipeIngredients`     | `string[]`  | List of ingredients                |
 | `RecipeInstructions`    | `string[]`  | List of instruction steps          |
 | `RecipeLanguageISOCode` | `string?`   | Language of the page (e.g. `"en"`) |

--- a/RecipeScraper/Models/ScrapedRecipe.cs
+++ b/RecipeScraper/Models/ScrapedRecipe.cs
@@ -9,6 +9,7 @@ public class ScrapedRecipe
     public string? Yield { get; set; }
     public TimeSpan? PrepTime { get; set; }
     public TimeSpan? CookTime { get; set; }
+    public TimeSpan? TotalTime { get; set; }
 
     public string[] RecipeIngredients { get; set; } = Array.Empty<string>();
     public string[] RecipeInstructions { get; set; } = Array.Empty<string>();

--- a/RecipeScraper/Parsers/Abstractions/IDocumentParser.cs
+++ b/RecipeScraper/Parsers/Abstractions/IDocumentParser.cs
@@ -12,6 +12,7 @@ internal interface IDocumentParser
     string? GetImage();
     TimeSpan? GetPrepTime();
     TimeSpan? GetCookTime();
+    TimeSpan? GetTotalTime();
     List<string> GetRecipeIngredients();
     List<string> GetRecipeInstructions();
 }

--- a/RecipeScraper/Parsers/HtmlTreeParser.cs
+++ b/RecipeScraper/Parsers/HtmlTreeParser.cs
@@ -76,6 +76,8 @@ internal class HtmlTreeParser : IDocumentParser
 
     public TimeSpan? GetCookTime() => null;
 
+    public TimeSpan? GetTotalTime() => null;
+
     public List<string> GetRecipeIngredients()
     {
         var recipeIngredients = new List<string>();

--- a/RecipeScraper/Parsers/JsonLdParser.cs
+++ b/RecipeScraper/Parsers/JsonLdParser.cs
@@ -119,6 +119,18 @@ namespace RecipeScraper.Parsers
             return null;
         }
 
+        public TimeSpan? GetTotalTime()
+        {
+            if (_jsonRecipe.TryGetProperty("totalTime", out JsonElement totalTimeElement) && totalTimeElement.ValueKind == JsonValueKind.String)
+            {
+                string? totalTime = totalTimeElement.GetString();
+                if (!string.IsNullOrEmpty(totalTime))
+                    return XmlConvert.ToTimeSpan(totalTime);
+            }
+
+            return null;
+        }
+
         public List<string> GetRecipeIngredients()
         {
             var recipeIngredients = new List<string>();

--- a/RecipeScraper/Parsers/MicrodataParser.cs
+++ b/RecipeScraper/Parsers/MicrodataParser.cs
@@ -77,6 +77,20 @@ namespace RecipeScraper.Parsers
             return cookTime != null ? XmlConvert.ToTimeSpan(cookTime) : null;
         }
 
+        public TimeSpan? GetTotalTime()
+        {
+            var totalTimeElement = AngleSharpHelpers.GetSingleItemPropElementFromPageContent("totalTime", _pageContent);
+
+            string? totalTime = totalTimeElement?.LocalName switch
+            {
+                "time" => totalTimeElement.GetAttribute("datetime"),
+                "meta" => totalTimeElement.GetAttribute("content"),
+                _ => totalTimeElement?.TextContent.Trim()
+            };
+
+            return totalTime != null ? XmlConvert.ToTimeSpan(totalTime) : null;
+        }
+
         public List<string> GetRecipeIngredients()
         {
             var ingredientElements = AngleSharpHelpers.GetMultipleItemPropElementsFromPageContent("recipeIngredient", _pageContent);

--- a/RecipeScraper/Scrapers/RecipeScraperBase.cs
+++ b/RecipeScraper/Scrapers/RecipeScraperBase.cs
@@ -29,6 +29,7 @@ public class RecipeScraperBase : IRecipeScraper
             Yield = GetYield(),
             PrepTime = GetPrepTime(),
             CookTime = GetCookTime(),
+            TotalTime = GetTotalTime(),
             RecipeIngredients = GetRecipeIngredients(),
             RecipeInstructions = GetRecipeInstructions(),
             RecipeLanguageISOCode = GetRecipeLanguageISOCode()
@@ -124,6 +125,21 @@ public class RecipeScraperBase : IRecipeScraper
                 var cookTime = formatScraper.GetCookTime();
                 if (cookTime != null)
                     return cookTime;
+            }
+        }
+
+        return null;
+    }
+
+    public virtual TimeSpan? GetTotalTime()
+    {
+        foreach (var formatScraper in _documentParsers)
+        {
+            if (formatScraper.IsActive)
+            {
+                var totalTime = formatScraper.GetTotalTime();
+                if (totalTime != null)
+                    return totalTime;
             }
         }
 


### PR DESCRIPTION
## Summary

- Add `TotalTime` (`TimeSpan?`) property to `ScrapedRecipe` model
- Implement `GetTotalTime()` in `IDocumentParser`, `JsonLdParser`, and `MicrodataParser`
- Add `GetTotalTime()` stub (returns `null`) in `HtmlTreeParser`
- Wire `TotalTime` through `RecipeScraperBase.ScrapeRecipe()`
- Update `README.md` and `CLAUDE.md` with new property

## Test plan

- [x] `dotnet build` passes with no errors
- [x] `dotnet test RecipeScraper.UnitTests` passes
- [x] Verify `TotalTime` is populated for a recipe with `totalTime` in JSON-LD (e.g. foodnetwork.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)